### PR TITLE
2.2x speedup - vectorize for loop in TBSM_Net.forward

### DIFF
--- a/tbsm_pytorch.py
+++ b/tbsm_pytorch.py
@@ -283,10 +283,10 @@ class TBSM_Net(nn.Module):
 
             #  Set offsets; resize if needed.
             curr_max_offset = (j_upper - j_lower) * n
-            if curr_max_offset > self.max_offset:
+            if curr_max_offset > self.max_offset + 1:
                 #  Resize offsets to 2x required size.
                 self.offsets = torch.tensor(list(range(curr_max_offset * 2))).to(self.offsets.device)
-                self.max_offset = curr_max_offset
+                self.max_offset = curr_max_offset * 2
 
             concatenated_lS_o = [self.offsets[: curr_max_offset] for j in range(len(lS_o[0]))]
 

--- a/tbsm_pytorch.py
+++ b/tbsm_pytorch.py
@@ -254,20 +254,71 @@ class TBSM_Net(nn.Module):
             f_mlp = np.array([self.num_mlps, self.num_mlps + 4, 1])
             self.final_mlp = dlrm.DLRM_Net().create_mlp(f_mlp, f_mlp.size - 2)
 
+        #  Offsets need to be stored beforehand if args.run_fast.
+        if args.run_fast:
+            #  Constant offsets tensor.
+            self.max_offset = 10000000
+            self.offsets = torch.tensor(list(range(self.max_offset)))
+            self.offsets_moved = False
+
     def forward(self, x, lS_o, lS_i):
+        #  Move offsets to device if needed.
+        if args.run_fast and not self.offsets_moved:
+            self.offsets = self.offsets.to(x[0].device)
+            self.offsets_moved = True
 
         # data point is history H and last entry w
         n = x[0].shape[0]  # batch_size
         ts = len(x)
         H = torch.zeros(n, self.ts_length, self.ln_top[-1]).to(x[0].device)
-        # split point into first part (history)
-        # and last item
-        for j in range(ts - self.ts_length - 1, ts - 1):
-            oj = j - (ts - self.ts_length - 1)
-            v = self.dlrm(x[j], lS_o[j], lS_i[j])
+
+        #  Compute H using either fast or original approach depending on args.run_fast.
+        if args.run_fast:
+            #  j determines access indices of input; first, determine j bounds and get all inputs.
+            j_lower = (ts - self.ts_length - 1)
+            j_upper = (ts - 1)
+
+            #  Concatenate x[j]s.
+            concatenated_x = torch.cat(x[j_lower : j_upper])
+
+            #  Set offsets; resize if needed.
+            curr_max_offset = (j_upper - j_lower) * n
+            if curr_max_offset > self.max_offset:
+                #  Resize offsets to 2x required size.
+                self.offsets = torch.tensor(list(range(curr_max_offset * 2))).to(self.offsets.device)
+                self.max_offset = curr_max_offset
+
+            concatenated_lS_o = [self.offsets[: curr_max_offset] for j in range(len(lS_o[0]))]
+
+            #  Concatenate lS_i[0, 1, 2]s.
+            concatenated_lS_i = [torch.cat([lS_i[i][j] for i in range(j_lower, j_upper)]) for j in range(len(lS_i[0]))]
+
+            #  oj determines access indices of output; determine oj bounds to assign output values in H. oj is just j indices adjusted to start at 0.
+            oj_lower = 0 - (ts - self.ts_length - 1)
+            oj_upper = (ts - 1) - (ts - self.ts_length - 1)
+
+            #  After fetching all inputs, run through DLRM.
+            concatenated_dlrm_output = self.dlrm(concatenated_x, concatenated_lS_o, concatenated_lS_i)
+
+            #  Reshape output with new ts dimension and transpose for H output.
+            transposed_concatenated_dlrm_output = torch.transpose(concatenated_dlrm_output.reshape((j_upper - j_lower), n, self.ln_top[-1]), 0, 1)
             if self.model_type == "tsl" and self.tsl_proj:
-                v = Functional.normalize(v, p=2, dim=1)
-            H[:, oj, :] = v
+                dlrm_output = Functional.normalize(transposed_concatenated_dlrm_output, p=2, dim=2)
+            else:
+                dlrm_output = transposed_concatenated_dlrm_output
+
+            #  Assign the output to H with correct oj bounds.
+            H[:, oj_lower : oj_upper, :] = dlrm_output
+
+        else:
+            # split point into first part (history)
+            # and last item
+            for j in range(ts - self.ts_length - 1, ts - 1):
+                oj = j - (ts - self.ts_length - 1)
+                v = self.dlrm(x[j], lS_o[j], lS_i[j])
+                if self.model_type == "tsl" and self.tsl_proj:
+                    v = Functional.normalize(v, p=2, dim=1)
+                H[:, oj, :] = v
 
         w = self.dlrm(x[-1], lS_o[-1], lS_i[-1])
         # project onto sphere
@@ -438,9 +489,9 @@ def data_wrap(X, lS_o, lS_i, use_gpu, device):
         return X, lS_o, lS_i
 
 
-def time_wrap(use_gpu):
+def time_wrap(use_gpu, device):
     if use_gpu:
-        torch.cuda.synchronize()
+        torch.cuda.synchronize(device)
     return time.time()
 
 
@@ -496,7 +547,6 @@ def iterate_train_data(args, train_ld, val_ld, tbsm, k, use_gpu, device, writer,
 
     # specify the optimizer algorithm
     optimizer = torch.optim.Adagrad(tbsm.parameters(), lr=args.learning_rate)
-
     total_time = 0
     total_loss = 0
     total_accu = 0
@@ -507,7 +557,7 @@ def iterate_train_data(args, train_ld, val_ld, tbsm, k, use_gpu, device, writer,
     for j, (X, lS_o, lS_i, T) in enumerate(train_ld):
         if j >= nbatches:
             break
-        t1 = time_wrap(use_gpu)
+        t1 = time_wrap(use_gpu, device)
         batchSize = X[0].shape[0]
         # forward pass
         Z = tbsm(*data_wrap(X,
@@ -519,6 +569,7 @@ def iterate_train_data(args, train_ld, val_ld, tbsm, k, use_gpu, device, writer,
 
         # loss
         E = loss_fn_wrap(Z, T, use_gpu, device)
+
         # compute loss and accuracy
         L = E.detach().cpu().numpy()  # numpy array
         z = Z.detach().cpu().numpy()  # numpy array
@@ -534,7 +585,7 @@ def iterate_train_data(args, train_ld, val_ld, tbsm, k, use_gpu, device, writer,
         # weights update
         optimizer.step()
 
-        t2 = time_wrap(use_gpu)
+        t2 = time_wrap(use_gpu, device)
         total_time += t2 - t1
         total_loss += (L * batchSize)
         total_accu += A
@@ -835,6 +886,7 @@ if __name__ == "__main__":
     parser.add_argument("--print-time", action="store_true", default=False)
     parser.add_argument("--enable-summary", action="store_true", default=False)
     parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--run-fast", action="store_true", default=False)
     args = parser.parse_args()
 
     # the code requires access to dlrm model


### PR DESCRIPTION
This PR adds an option, --run-fast, to tbsm_pytorch.py to allow the benchmark script to run ~2.2x faster end-to-end (tbsm_bench.sh). The change vectorizes the for loop which computes the H tensor in TBSM_Net.forward, resulting in that section of the code running >10x faster.

This vectorization has the effect of a 20x (for a TS length of 20) larger batch size than before being passed through the DLRM in the TBSM, and due to [PyTorch's way of optimizing computations](https://discuss.pytorch.org/t/numerical-error-between-batch-and-single-instance-computation/56735) does not produce bit-equivalent outputs. Using a Kolmogorov-Smirnov test over 20 random seeds, it has been confirmed the change to speed up the code makes no difference to the test set accuracy, and in fact it very slightly improved the average.

The PR also includes a miscellaneous change to the synchronize call in time_wrap so that extra memory does not get used up on GPU 0 regardless of what GPU is actually used for training.

This work was done in collaboration with primarily Tigran Ishkanov, as well as others, at Facebook - Aravind Kalaiah, Maxim Naumov, Bichen Wu, and Dheevatsa Mudigere.